### PR TITLE
Return undefined if there's no active dp

### DIFF
--- a/examples/vote.ts
+++ b/examples/vote.ts
@@ -25,20 +25,12 @@ async function run() {
   console.log('Delegatee is ', delegatee);
 
   const getDistributionPeriod = async () => {
-    let distributionPeriod: DistributionPeriod;
-    try {
+    let distributionPeriod: DistributionPeriod | undefined;
+    distributionPeriod = await ajna.grants.getActiveDistributionPeriod();
+    if (distributionPeriod === undefined) {
+      const tx = await startNewDistributionPeriod(signerVoter);
+      await tx.verifyAndSubmit();
       distributionPeriod = await ajna.grants.getActiveDistributionPeriod();
-    } catch (e) {
-      if (
-        e instanceof SdkError &&
-        e.message === 'There is no active distribution period, starting a new one'
-      ) {
-        const tx = await startNewDistributionPeriod(signerVoter);
-        await tx.verifyAndSubmit();
-        distributionPeriod = await ajna.grants.getActiveDistributionPeriod();
-      } else {
-        throw e;
-      }
     }
     return distributionPeriod;
   };
@@ -47,13 +39,33 @@ async function run() {
 
   console.log('Distribution period', distributionPeriodData);
 
-  const distributionPeriod = await ajna.grants.getDistributionPeriod(distributionPeriodData.id);
+  if (distributionPeriodData) {
+    const distributionPeriod = await ajna.grants.getDistributionPeriod(distributionPeriodData?.id);
 
-  const screeningVotes = await distributionPeriod.getScreeningVotingPower(voterAddress);
+    const screeningVotes = await distributionPeriod.getScreeningVotingPower(voterAddress);
 
-  console.log('Voting power: ', fromWad(screeningVotes));
+    console.log('Voting power: ', fromWad(screeningVotes));
 
-  async function castVotes() {
+    const currentVotingPower = await castVotes(distributionPeriod);
+
+    console.log('Current Voting Power: ', currentVotingPower);
+
+    const screeningVotesCastData = await distributionPeriod.getScreeningVotesCast(voterAddress);
+    console.log('Screening votes cast: ', screeningVotesCastData);
+
+    const fundingVotesCastData = await distributionPeriod.getFundingVotesCast(voterAddress);
+    console.log('Funding votes cast: ', fundingVotesCastData);
+
+    const isDistributionPeriodOnScreeningStage =
+      (await distributionPeriod.distributionPeriodStage()) === DistributionPeriodStage.SCREENING;
+
+    if (!isDistributionPeriodOnScreeningStage) {
+      const voterInfo = await distributionPeriod.getVoterInfo(delegatee);
+      console.log('Voter Info', voterInfo);
+    }
+  }
+
+  async function castVotes(distributionPeriod: DistributionPeriod) {
     const tx = await distributionPeriod.castVotes(signerVoter, [
       ['0x22bf669502c9c2673093a4ef1dede6c878e1157eb773c221b87db4fed622256e', '1'],
     ]);
@@ -61,24 +73,6 @@ async function run() {
     console.log(fromWad(estimatedGas), 'estimated gas required for this transaction');
     const recepit = await tx.verifyAndSubmit();
     console.log(recepit);
-  }
-
-  const currentVotingPower = await castVotes();
-
-  console.log('Current Voting Power: ', currentVotingPower);
-
-  const screeningVotesCastData = await distributionPeriod.getScreeningVotesCast(voterAddress);
-  console.log('Screening votes cast: ', screeningVotesCastData);
-
-  const fundingVotesCastData = await distributionPeriod.getFundingVotesCast(voterAddress);
-  console.log('Funding votes cast: ', fundingVotesCastData);
-
-  const isDistributionPeriodOnScreeningStage =
-    (await distributionPeriod.distributionPeriodStage()) === DistributionPeriodStage.SCREENING;
-
-  if (!isDistributionPeriodOnScreeningStage) {
-    const voterInfo = await distributionPeriod.getVoterInfo(delegatee);
-    console.log('Voter Info', voterInfo);
   }
 }
 

--- a/src/classes/GrantFund.ts
+++ b/src/classes/GrantFund.ts
@@ -114,11 +114,11 @@ export class GrantFund extends ContractBase implements IGrantFund {
     const provider = this.getProvider() as Provider;
     const distributionId = await getCurrentDistributionId(provider);
     if (distributionId === 0) {
-      throw new SdkError('There is no active distribution period');
+      return undefined;
     }
     const currentDistributionPeriod = await this.getDistributionPeriod(distributionId);
     if (!currentDistributionPeriod.isActive) {
-      throw new SdkError('There is no active distribution period');
+      return undefined;
     }
     return currentDistributionPeriod;
   }

--- a/src/tests/grant-fund.spec.ts
+++ b/src/tests/grant-fund.spec.ts
@@ -54,10 +54,8 @@ describe('Grants fund', () => {
   });
 
   describe('Distribution Period', () => {
-    it(`throws and error getting active distribution period if it doesn't exist`, async () => {
-      await expect(ajna.grants.getActiveDistributionPeriod()).rejects.toThrow(
-        'There is no active distribution period'
-      );
+    it(`should return undefined if distribution period doesn't exist`, async () => {
+      expect(await ajna.grants.getActiveDistributionPeriod()).toBeUndefined();
     });
 
     it('start new distribution period', async () => {
@@ -76,14 +74,17 @@ describe('Grants fund', () => {
 
     it('should get the active distribution period', async () => {
       const dp = await ajna.grants.getActiveDistributionPeriod();
-      expect(dp.id).toBe(2);
-      expect(dp.startBlock).toBeDefined();
-      expect(dp.endBlock).toBeDefined();
-      expect(dp.startDate).toBeDefined();
-      expect(dp.endDate).toBeDefined();
-      expect(dp.isActive).toBe(true);
-      expect(fromWad(dp.votesCount)).toBe('0.0');
-      expect(fromWad(dp.fundsAvailable)).toBe('0.0');
+      expect(dp).toBeDefined();
+      const votesCount = fromWad(dp?.votesCount || 0);
+      const fundsAvailable = fromWad(dp?.fundsAvailable || 0);
+      expect(dp?.id).toBe(2);
+      expect(dp?.startBlock).toBeDefined();
+      expect(dp?.endBlock).toBeDefined();
+      expect(dp?.startDate).toBeDefined();
+      expect(dp?.endDate).toBeDefined();
+      expect(dp?.isActive).toBe(true);
+      expect(votesCount).toBe('0.0');
+      expect(fundsAvailable).toBe('0.0');
     });
 
     it('should get the distribution by id', async () => {
@@ -161,7 +162,9 @@ describe('Grants fund', () => {
   describe('Voting', () => {
     it('distribution period should be on screening stage', async () => {
       const currentDistributionPeriod = await ajna.grants.getActiveDistributionPeriod();
-      distributionPeriod = await ajna.grants.getDistributionPeriod(currentDistributionPeriod.id);
+      if (currentDistributionPeriod) {
+        distributionPeriod = await ajna.grants.getDistributionPeriod(currentDistributionPeriod.id);
+      }
       const isOnScreeningStage =
         (await distributionPeriod.distributionPeriodStage()) === DistributionPeriodStage.SCREENING;
       expect(isOnScreeningStage).toBe(true);

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -131,7 +131,7 @@ export interface IGrantFund {
   /** get the current grants treasury */
   getTreasury(): Promise<BigNumber>;
   /** get the active distribution period */
-  getActiveDistributionPeriod(): Promise<IDistributionPeriod>;
+  getActiveDistributionPeriod(): Promise<IDistributionPeriod | undefined>;
   /** get a distribution period by id */
   getDistributionPeriod(distributionId: number): Promise<IDistributionPeriod>;
   /** creates a proposal */


### PR DESCRIPTION
Due to UI requirements, `getActiveDistributionPeriod` shouldn't throw an error when there's no active distribution period but it should return `undefined` 