### PR TITLE
add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ajna-finance/v1-sdk",
   "description": "A typescript SDK that can be used to create Dapps in Ajna ecosystem.",
-  "version": "0.1.19-dev",
+  "version": "0.1.20-dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/ajna-finance/v1-sdk.git"


### PR DESCRIPTION
in order to correctly install `v1-sdk` to the dapp repo via spheron, we need to set the package registry so that spheron knows where to find it without having to revert to our `.npmrc` approach.

unfortunately, spheron does not have a `Shared Environment Variables` option, like vercel does:

![Screenshot 2023-09-14 at 11 39 41 AM](https://github.com/ajna-finance/v1-sdk/assets/18040654/5249a84d-769d-4db2-a45c-c78806286c9d)

[docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#publishing-a-package-using-publishconfig-in-the-packagejson-file):
![Screenshot 2023-09-14 at 11 30 41 AM](https://github.com/ajna-finance/v1-sdk/assets/18040654/794168d7-de84-43c9-b1a1-f2b271026a13)
