### PR TITLE
stamp loan functionality

### DIFF
--- a/src/classes/Pool.ts
+++ b/src/classes/Pool.ts
@@ -19,6 +19,7 @@ import {
   increaseLPAllowance,
   updateInterest,
   lenderInfo,
+  stampLoan,
 } from '../contracts/pool';
 import {
   borrowerInfo,
@@ -759,6 +760,15 @@ export abstract class Pool {
   async updateInterest(signer: Signer) {
     const contractPoolWithSigner = this.contract.connect(signer);
     return updateInterest(contractPoolWithSigner);
+  }
+
+  /**
+   * updates the neutral price of a borrower's own loan, often useful after partial repayment
+   * @param borrower borrower who wishes to stamp their own loan
+   */
+  async stampLoan(signer: Signer) {
+    const contractPoolWithSigner = this.contract.connect(signer);
+    return stampLoan(contractPoolWithSigner);
   }
 
   /**

--- a/src/contracts/pool.ts
+++ b/src/contracts/pool.ts
@@ -115,6 +115,10 @@ export async function increaseLPAllowance(
   );
 }
 
+export async function stampLoan(contract: Contract, overrides?: TransactionOverrides) {
+  return await createTransaction(contract, { methodName: 'stampLoan', args: [] }, overrides);
+}
+
 export async function lenderKick(
   contract: Contract,
   index: number,


### PR DESCRIPTION
**Changes**
- Implemented `stampLoan`, allowing borrowers to update their neutral price.  They can make a decision to call this if they partially repay without removing any collateral, depending on how the market price has changed during origination.  The loan is implicitly restamped if collateral is removed during repayment.
- Updated draw/repay tests to use meaningful amounts of quote token.